### PR TITLE
Handle age gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,14 +36,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.68"
+name = "async-compression"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "62b74f44609f0f91493e3082d3734d98497e094777144380ea4db9f9905dd5b6"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -36,6 +64,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -108,6 +151,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
+dependencies = [
+ "cookie",
+ "idna 0.2.3",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +193,15 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -190,7 +270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -252,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d09067bfacaa79114679b279d7f5885b53295b1e2cfb4e79c8e4bd3d633169"
+checksum = "519b83cd10f5f6e969625a409f735182bea5558cd8b64c655806ceaae36f1999"
 
 [[package]]
 name = "dtoa-short"
@@ -314,6 +394,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -436,6 +526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "h2"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,18 +558,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "home"
@@ -580,6 +667,27 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
@@ -613,7 +721,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -626,9 +734,9 @@ checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "jni"
@@ -743,6 +851,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,12 +936,21 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -856,7 +982,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -903,7 +1029,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -1006,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -1042,18 +1168,34 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.28"
+name = "psl-types"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -1176,8 +1318,11 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1199,6 +1344,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1206,6 +1352,12 @@ dependencies = [
  "web-sys",
  "winreg 0.10.1",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"
@@ -1218,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -1232,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "same-file"
@@ -1247,11 +1399,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1325,29 +1477,29 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
  "itoa",
  "ryu",
@@ -1356,13 +1508,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
+checksum = "1d89a8107374290037607734c0b73a85db7ed80cae314b3c5791f192a496e731"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1422,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -1481,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1532,22 +1684,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1562,12 +1714,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
+ "itoa",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1575,6 +1729,15 @@ name = "time-core"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"
@@ -1593,11 +1756,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -1617,7 +1781,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1670,7 +1834,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1722,9 +1886,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-normalization"
@@ -1748,7 +1912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.4.0",
  "percent-encoding",
 ]
 
@@ -1775,6 +1939,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -1828,7 +1998,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -1862,7 +2032,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1916,21 +2086,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
@@ -1944,7 +2099,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -1964,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "async-trait",
  "discord-sdk",
  "html-escape",
+ "once_cell",
  "reqwest",
  "reqwest_cookie_store",
  "scraper",
@@ -1538,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,13 +162,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "cookie_store"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
 dependencies = [
- "cookie",
+ "cookie 0.16.2",
  "idna 0.2.3",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
+dependencies = [
+ "cookie 0.17.0",
+ "idna 0.3.0",
  "log",
  "publicsuffix",
  "serde",
@@ -295,6 +323,7 @@ dependencies = [
  "discord-sdk",
  "html-escape",
  "reqwest",
+ "reqwest_cookie_store",
  "scraper",
  "serde",
  "serde_json",
@@ -1321,8 +1350,8 @@ dependencies = [
  "async-compression",
  "base64",
  "bytes",
- "cookie",
- "cookie_store",
+ "cookie 0.16.2",
+ "cookie_store 0.16.2",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1351,6 +1380,18 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg 0.10.1",
+]
+
+[[package]]
+name = "reqwest_cookie_store"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba529055ea150e42e4eb9c11dcd380a41025ad4d594b0cb4904ef28b037e1061"
+dependencies = [
+ "bytes",
+ "cookie_store 0.20.0",
+ "reqwest",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ include = [
 sysinfo = "0.28"
 anyhow = "1.0"
 scraper = "0.15.0"
+reqwest_cookie_store = "0.6"
 tokio = {version = "1", features = ["signal", "fs", "sync", "macros", "rt-multi-thread", "io-util", "io-std"]}
 serde = {version = "^1", features = ["default", "derive"]}
 serde_json = "^1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ include = [
 sysinfo = "0.28"
 anyhow = "1.0"
 scraper = "0.15.0"
+once_cell = "1.18"
 reqwest_cookie_store = "0.6"
 tokio = {version = "1", features = ["signal", "fs", "sync", "macros", "rt-multi-thread", "io-util", "io-std"]}
 serde = {version = "^1", features = ["default", "derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ include = [
 sysinfo = "0.28"
 anyhow = "1.0"
 scraper = "0.15.0"
-reqwest = {version = "^0.11"}
 tokio = {version = "1", features = ["signal", "fs", "sync", "macros", "rt-multi-thread", "io-util", "io-std"]}
 serde = {version = "^1", features = ["default", "derive"]}
 serde_json = "^1"
@@ -32,6 +31,11 @@ discord-sdk = "0.3"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 html-escape = "0.2.13"
+
+[dependencies.reqwest]
+version = "0.11"
+features = ["default", "gzip", "cookies"]
+
 
 [profile.release]
 opt-level = "s"

--- a/README.md
+++ b/README.md
@@ -49,3 +49,8 @@ After that run `systemctl --user daemon-reload` and `systemctl --user enable --n
 
 Check if everything is running by running `systemctl --user status discord-rpc-helper.service`.
 
+## Quirks and features
+
+### Steam Age Gate
+
+When a game requires an age gate to get to the Steam Store page, we handle the age gate by submitting an age of 1/1/1990.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use discord_sdk::{
     DiscordApp,
     Subscriptions,
     wheel::Wheel,
-    activity::{ ActivityBuilder }
+    activity::ActivityBuilder
 };
 use tracing::{debug, info, error, event, Level};
 

--- a/src/steam/cache.rs
+++ b/src/steam/cache.rs
@@ -1,26 +1,56 @@
 
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc, fs::File, io::{BufReader, BufWriter}, collections::HashMap};
 use anyhow::{Result, anyhow, Context};
 use scraper::{Selector, ElementRef, Html};
 use url::Url;
-use tokio::fs::{read_to_string, write};
+use tokio::fs::{read_to_string, write };
 use html_escape::decode_html_entities;
+use reqwest_cookie_store::{CookieStore, CookieStoreMutex};
 
 // XDG RUNTIME HOME
 
 const XDG_RUNTIME_ENV_VAR: &str = "XDG_RUNTIME_DIR";
 const CACHE_DIR: &str = "cache";
+const COOKIE_STORE_PATH: &str = "cookies.json";
 
 const STEAM_NAME_SELECTOR: &str = "#appHubAppName";
 const STEAM_ICON_SELECTOR: &str = "div.apphub_AppIcon img";
 
-#[derive(Debug, PartialEq, Eq)]
+const AGEGATE_SELECTOR: &str = "div.agegate_birthday_selector";
+const AGESET_BASE_URL: &str = "https://store.steampowered.com/agecheckset/app/";
+
+const SESSION_ID_COOKIE_NAME: &str = "sessionid";
+const SESSION_ID_COOKIE_DOMAIN: &str = "store.steampowered.com";
+
+#[derive(Debug)]
 pub struct DocumentCache {
     /// The location of the document cache in the file system
     location: String,
+    cookies: Arc<CookieStoreMutex>,
 }
 
 impl DocumentCache {
+
+    /// Creates a new [DocumentCache](#DocumentCache) with the given location.
+    pub fn new(cache_loc: String) -> Self {
+        let mut location = PathBuf::new();
+        location.push(&cache_loc);
+        
+        let cookie_store = {
+            location.push(COOKIE_STORE_PATH);
+            if let Ok(file) = File::open(&location).map(BufReader::new)
+            {
+                CookieStore::load_json(file).unwrap()
+            } else {
+                CookieStore::new(None)
+            }
+        };
+        
+        let cookie_store = CookieStoreMutex::new(cookie_store);
+        let cookie_store = Arc::new(cookie_store);
+
+        Self { location: cache_loc, cookies: cookie_store }
+    }
 
     /// Get a game's name.
     /// 
@@ -30,7 +60,7 @@ impl DocumentCache {
     /// * `steam_url: &str`: the url of the game's steam store page
     pub async fn get_name(&self, steam_url: &str) -> Result<String> {
         let name_selector = Selector::parse(STEAM_NAME_SELECTOR).unwrap();
-        let html = match self.get_steamdb_page(steam_url).await {
+        let html = match self.get_steam_page(steam_url).await {
             Ok(h) => get_html(&h),
             Err(err) => return Err(anyhow!(err)),
         };
@@ -51,7 +81,7 @@ impl DocumentCache {
     /// * `steam_url: &str`: the url of the game's steam store page
     pub async fn get_appicon(&self, steam_url: &str) -> Result<String> {
         let img_selector = Selector::parse(STEAM_ICON_SELECTOR).unwrap();
-        let html = self.get_steamdb_page(steam_url).await.map(|h| get_html(&h))?;
+        let html = self.get_steam_page(steam_url).await.map(|h| get_html(&h))?;
     
         let found_elements: Vec<ElementRef> = html.select(&img_selector).collect();
         match found_elements.len() {
@@ -62,7 +92,7 @@ impl DocumentCache {
     }
     
     /// Downloads the given url, if available
-    async fn get_steamdb_page(&self, url: &str) -> Result<String> {
+    async fn get_steam_page(&self, url: &str) -> Result<String> {
         // Check if cache exists
         let cache_path = self.get_cache_path(url)?;
 
@@ -70,7 +100,7 @@ impl DocumentCache {
             true => Ok(read_to_string(&cache_path).await?),
             false => {
                 // get supposed cache path
-                let document = reqwest::get(url).await?.text().await?;
+                let document = self.download_steam_page(url).await?;
     
                 write(&cache_path, &document).await?;
 
@@ -79,18 +109,89 @@ impl DocumentCache {
         }
     }
 
-    fn get_cache_path(&self, url: &str) -> Result<PathBuf> {
-        let parsed_url = Url::parse(url)?;
-        let steamid_url_part = parsed_url.path_segments()
-            .with_context(|| format!("Could not find path in url {url}"))?
-            .find_map(|p| p.parse::<i64>().ok())
-            .with_context(|| format!("Could not find steam id in url {url}"))?;
+    async fn download_steam_page(&self, url: &str) -> Result<String> {
+        let rest_client = self.build_client().with_context(|| "Error building rest client for cache")?;
 
+        let request = rest_client.get(url).build()?;
+        let response = rest_client.execute(request).await?;
+        
+
+        
+
+        let (resp_content, is_age_gate) ={ 
+            let resp_html = get_html(response.text().await?.as_str());
+
+            let is_age_gate = {
+                let gate_selector = Selector::parse(AGEGATE_SELECTOR).unwrap();
+                let mut age_gate_div = resp_html.select(&gate_selector);
+    
+                age_gate_div.next().is_some()
+            };
+
+            (resp_html.html(), is_age_gate)
+        };
+
+        if is_age_gate {
+            let app_id = Self::get_appid_from_url(url)?;
+            let resp_content = self.handle_agegate(app_id, &rest_client).await?;
+            Ok(resp_content)
+        }  else {
+            Ok(resp_content)
+        }
+    }
+
+    fn build_client(&self) -> Result<reqwest::Client> {
+        reqwest::ClientBuilder::new()
+                .cookie_provider(Arc::clone(&self.cookies)).
+                build().with_context(|| "Error building reqwest client")
+    }
+
+    fn get_session_cookie_value(&self) -> Result<String> {
+        let cookies = self.cookies.lock().unwrap();
+
+        if let Some(session_cookie) = cookies.get(SESSION_ID_COOKIE_DOMAIN, "/", SESSION_ID_COOKIE_NAME) {
+            let cookie_value = session_cookie.value();
+            Ok(cookie_value.to_owned())
+        } else {
+            Err(anyhow!("We encountered an age gate, but did not manage to capture a session cookie yet"))
+        }
+    }
+    
+    async fn handle_agegate(&self, app_id: i64, client: &reqwest::Client) -> Result<String> {
+        let session_id = self.get_session_cookie_value()?;
+        
+        // time to lie about our age (or not, in some freak occurrences)
+        let mut ageset_form = HashMap::new();
+        ageset_form.insert("sessionid", session_id.as_str());
+        ageset_form.insert("ageDay", "1");
+        ageset_form.insert("ageMonth", "January");
+        ageset_form.insert("ageYear", "1990");
+
+        let ageset_post = client.post(format!("{}{}", AGESET_BASE_URL, app_id))
+                .form(&ageset_form)
+                .build()?;
+
+        let ageset_resp = client.execute(ageset_post).await?;
+
+        todo!()
+    }
+
+    fn get_cache_path(&self, url: &str) -> Result<PathBuf> {
+        let steamid_url_part = Self::get_appid_from_url(url)?;
         let mut path_buff = self.get_location_pathbuf();
 
         path_buff.push(format!("{steamid_url_part}.html"));
 
         Ok(path_buff)
+    }
+
+    fn get_appid_from_url(url: &str) -> Result<i64> {
+        let parsed_url = Url::parse(url)?;
+
+        parsed_url.path_segments()
+            .with_context(|| format!("Could not find path in url {url}"))?
+            .find_map(|p| p.parse::<i64>().ok())
+            .with_context(|| format!("Could not find steam id in url {url}"))
     }
 
     /// Create `PathBuf` from `DocumentCache.location`
@@ -100,6 +201,31 @@ impl DocumentCache {
         path_buff.push(&self.location);
 
         path_buff
+    }
+
+    /// Save cookies to temp location.
+    /// 
+    /// This allows to reuse age gates after app restarts.
+    fn save_cookies(&self) {
+        let mut writer = {
+            let mut cache_path = self.get_location_pathbuf();
+            cache_path.push(COOKIE_STORE_PATH);
+
+            if cache_path.is_file() {
+                File::open(cache_path).map(BufWriter::new).unwrap()
+            } else {
+                File::create(cache_path).map(BufWriter::new).unwrap()
+            }
+        };
+
+        let store = self.cookies.lock().unwrap();
+        store.save_json(&mut writer).unwrap();
+    }
+}
+
+impl Drop for DocumentCache {
+    fn drop(&mut self) {
+        self.save_cookies();
     }
 }
     
@@ -136,8 +262,8 @@ impl DocumentCacheBuilder {
     /// This consumes the builder.
     pub fn build(self) -> Result<DocumentCache> {
         match self.location {
-            Some(l) => create_cache_dir(l.as_str()).with_context(|| "Error building document cache").map(|p| DocumentCache { location: p}),
-            None => create_cache_dir(get_runtime_path().expect("Could not determine XDG_RUNTIME_DIR").as_str()).map(|p| DocumentCache { location: p})
+            Some(l) => create_cache_dir(l.as_str()).with_context(|| "Error building document cache").map(DocumentCache::new),
+            None => create_cache_dir(get_runtime_path().expect("Could not determine XDG_RUNTIME_DIR").as_str()).map(DocumentCache ::new)
         }
     }
 }

--- a/src/steam/scanner.rs
+++ b/src/steam/scanner.rs
@@ -1,4 +1,4 @@
-use super::{*, cache::DocumentCacheBuilder};
+use super::{*};
 use sysinfo::{Process, ProcessExt, RefreshKind, System, SystemExt};
 use anyhow::Result;
 
@@ -12,14 +12,11 @@ fn process_to_steamapp(steamproc: &Process) -> Option<SteamApp> {
         .unwrap_or(None);
 
     path.as_ref()?;
-    
-    let cache = DocumentCacheBuilder::new().build().expect("Error creating the document cache");
 
     Some(SteamApp {
         app_id: steamproc.steam_appid(),
         path: path.unwrap(),
         running_since: steamproc.start_time() as i64,
-        cache
     })
 }
 


### PR DESCRIPTION
When Steam redirects us to an age gate, we submit a DoB of 1/1/1990. We also keep the cookie in the cache, so it'll be valid until the session times out or the computer is restarted.
